### PR TITLE
Further monitor enhancements

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2883,7 +2883,7 @@ void HandleMapNotify(const evh_args_t *ea)
 	Bool is_on_this_page = False;
 	const XEvent *te = ea->exc->x.etrigger;
 	FvwmWindow * const fw = ea->exc->w.fw;
-	struct monitor *m = monitor_get_current();
+	struct monitor *m = (fw && fw->m) ? fw->m : monitor_get_current();
 
 	DBUG("HandleMapNotify", "Routine Entered");
 

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -1879,13 +1879,9 @@ static int __place_window(
 
 	/* Check the desk here. */
 	if (!SUSE_START_ON_DESK(&pstyle->flags)) {
-		struct monitor *mnew;
-
-		mnew = FindScreenOfXY(attr_g->x, attr_g->y);
-
+		struct monitor *mnew = FindScreenOfXY(attr_g->x, attr_g->y);
+		fw->m = mnew;
 		fw->Desk = mnew->virtual_scr.CurrentDesk;
-
-		fprintf(stderr, "%s: set desk now to: %d\n", __func__, fw->Desk);
 	}
 
 	reason->pos.x = attr_g->x;

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2225,7 +2225,19 @@ void CMD_DesktopSize(F_CMD_ARGS)
  */
 void CMD_GotoDesk(F_CMD_ARGS)
 {
-	struct monitor	*m = monitor_get_current();
+	struct monitor  *m_use = monitor_get_current(), *m;
+	char		*action_cpy, *token;
+
+	action_cpy = strdup(action);
+	token = PeekToken(action_cpy, &action_cpy);
+
+	m = monitor_by_name(token);
+	if (strcmp(m->si->name, token) != 0)
+		m = m_use;
+	else
+		PeekToken(action, &action);
+
+	fprintf(stderr, "%s: using monitor: %s\n", __func__, m->si->name);
 
 	goto_desk(GetDeskNumber(m, action, m->virtual_scr.CurrentDesk), m);
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -48,7 +48,7 @@
 
 extern ScreenInfo Scr;
 extern Display *dpy;
-extern char *monitor_to_track; 
+extern char *monitor_to_track;
 
 Pixel back_pix, fore_pix, hi_pix;
 Pixel focus_pix;
@@ -1639,7 +1639,7 @@ void MovePage(Bool is_new_desk)
       sptr = Desks[mon->virtual_scr.CurrentDesk -desk1].label;
     else
     {
-      sprintf(str, "GotoDesk %d", mon->virtual_scr.CurrentDesk);
+      sprintf(str, "GotoDesk %s %d", mon->name, mon->virtual_scr.CurrentDesk);
       sptr = &str[0];
     }
 
@@ -1701,6 +1701,9 @@ void DrawGrid(int desk, int erase, Window ew, XRectangle *r)
 	XRectangle bound;
 	Region region = 0;
 	struct fpmonitor *mon = fpmonitor_this();
+
+	if (mon == NULL)
+		return;
 
 	if((desk < 0 ) || (desk >= ndesks))
 		return;
@@ -1929,10 +1932,11 @@ void DrawIconGrid(int erase)
 
 void SwitchToDesk(int Desk)
 {
-  char command[256];
+	char command[256];
+	struct fpmonitor *m = fpmonitor_this();
 
-  sprintf(command, "GotoDesk 0 %d", Desk + desk1);
-  SendText(fd,command,0);
+	sprintf(command, "GotoDesk %s 0 %d", m->name, Desk + desk1);
+	SendText(fd,command,0);
 }
 
 


### PR DESCRIPTION
When dealing with window placement when mapping windows, ensure the
correct screen is used.  Previously, the current screen was used for
some calculations, despite the fact that the operand window was on a
different scree.  This caused problems.

Elsewhere, use the correct screen when appropriate to do so.